### PR TITLE
feat: enable multivideo in a track

### DIFF
--- a/frontend/src/components/Timeline.svelte
+++ b/frontend/src/components/Timeline.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
   import TimelineArrow from "../icons/TimelineArrow.svelte";
   import { dropzone } from "../lib/dnd";
-  import { trackFiles, selectedTrack } from "../stores";
+  import { trackStore, selectedTrack } from "../stores";
   import { onDestroy } from "svelte";
   import type { main } from "wailsjs/go/models";
   import { GenerateThumbnail } from "../../wailsjs/go/main/App";
   import { videoStore } from "../stores";
 
+  const { getDuration, currentTime } = videoStore;
+
   let hoverPos = 0;
   let moveTimeline = false;
   let timestamp = new Date().getTime();
   let trackNode: HTMLDivElement;
-
-  const { getDuration, currentTime } = videoStore;
 
   $: {
     if (trackNode) {
@@ -67,7 +67,7 @@
   }
 
   onDestroy(() => {
-    trackFiles.reset();
+    trackStore.reset();
     hoverPos = 0;
   });
 </script>
@@ -79,7 +79,7 @@
   on:mouseup={() => stopTimelineBar()}
   on:mousemove={(e) => handleTimelineMove(e)}
 >
-  {#if $trackFiles.length <= 0}
+  {#if $trackStore.length <= 0}
     <div class="flex justify-center items-center">
       <p class="text-white text-4xl font-semibold select-none">
         Drag And Drop Video Clips
@@ -92,19 +92,24 @@
   {/if}
 
   <!-- VIDEO TRACKS -->
-  {#each $trackFiles as track (track.filepath + track.name)}
-    <div
-      class="w-1/4 h-28 bg-teal rounded-md border-white border-2 video-track cursor-pointer"
-      on:click={() => viewVideo(track)}
-      bind:this={trackNode}
-    >
-      <img
-        src={loadThumbnail(track) + `?${timestamp}`}
-        alt={`video: ${track.name}`}
-        class="h-full w-full select-none"
-        draggable={false}
-        on:error={() => createThumbnail(track)}
-      />
+  <!-- TODO Create an actual id for a track -->
+  {#each $trackStore as track, id (id)}
+    <div class="w-fit h-28 flex items-center">
+      {#each track as video (video.filepath + video.name)}
+        <div
+          class="h-28 bg-teal rounded-md border-white border-2 video-track cursor-pointer"
+          on:click={() => viewVideo(video)}
+          bind:this={trackNode}
+        >
+          <img
+            src={loadThumbnail(video) + `?${timestamp}`}
+            alt={`video: ${video.name}`}
+            class="h-full w-full select-none"
+            draggable={false}
+            on:error={() => createThumbnail(video)}
+          />
+        </div>
+      {/each}
     </div>
   {/each}
 </div>

--- a/frontend/src/lib/dnd.ts
+++ b/frontend/src/lib/dnd.ts
@@ -1,4 +1,4 @@
-import { draggedVideo, trackFiles } from "../stores";
+import { draggedVideo, trackStore } from "../stores";
 import type { main } from "../../wailsjs/go/models";
 
 export function draggable(node: HTMLDivElement, data: main.Video) {
@@ -61,7 +61,8 @@ export function dropzone(node: HTMLDivElement, opts) {
   ) {
     e.preventDefault();
     e.currentTarget.classList.remove(state.dragOverClass);
-    trackFiles.addVideos([draggedVideo.value()]);
+    // TODO: add to different tracks dynamically for now 0
+    trackStore.addVideoToTrack(0, draggedVideo.value());
   }
 
   node.addEventListener("dragenter", handleDragEnter);

--- a/frontend/src/stores.ts
+++ b/frontend/src/stores.ts
@@ -78,6 +78,38 @@ function createVideoTransferStore() {
   };
 }
 
+function createTracksStore() {
+  const { subscribe, set, update } = writable<main.Video[][]>([]);
+  let videoSet = [];
+
+  const addVideoToTrack = (id: number, video: main.Video) => {
+    // TODO: handle duplicated keys
+    update((tracks) => {
+      if (tracks.length === 0 || id > tracks.length) {
+        videoSet.push(new Set<string>([video.filepath + video.name]));
+        tracks.push([video]);
+      } else if (id >= 0 && id < tracks.length) {
+        if (!videoSet[id].has(video.filepath + video.name)) {
+          videoSet[id].add(video.filepath + video.name);
+          tracks[id] = [...tracks[id], video];
+        }
+      }
+      return tracks;
+    });
+  };
+
+  const reset = () => {
+    set([]);
+    videoSet = [];
+  };
+
+  return {
+    subscribe,
+    addVideoToTrack,
+    reset,
+  };
+}
+
 function createVideoStore() {
   const duration = writable<number>(0);
   const currentTime = writable<number>(0.0);
@@ -136,7 +168,7 @@ function createVideoStore() {
 
 export const router = createTwoPageRouterStore();
 export const videoFiles = createFilesytemStore();
-export const trackFiles = createFilesytemStore();
+export const trackStore = createTracksStore();
 export const projectName = writable("");
 export const currentVideo = writable("");
 export const selectedTrack = writable("");


### PR DESCRIPTION
## Description
This PR creates the ```trackStore``` which enables now multivideo on a single track. For now videos are organized on track 0.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
#5 Feature: Multivideo track
#3 Bug: Avoid duplicate key values on value drop
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

https://github.com/k1nho/gahara/assets/59541661/c54b6ca3-bd6f-4bf5-8236-c5126629750c


<!-- Visual changes require screenshots -->

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
